### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Build the C++ BMI example from a condaforge/miniforge3 (Linux/Ubuntu) base.
 FROM csdms/bmi:0.2.1
 
-LABEL author="Mark Piper"
-LABEL email="mark.piper@colorado.edu"
+LABEL org.opencontainers.image.authors="Mark Piper <mark.piper@colorado.edu>"
+LABEL org.opencontainers.image.url="https://hub.docker.com/r/csdms/bmi-example-cxx"
+LABEL org.opencontainers.image.source="https://github.com/csdms/bmi-example-cxx-docker"
+LABEL org.opencontainers.image.vendor="CSDMS"
 
 ENV base_url=https://github.com/csdms
 ENV project=bmi-example-cxx

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR ${prefix}/_build
 RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
     make && \
     make test && \
-    make install
+    make install && \
+    make clean
 
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ LABEL author="Mark Piper"
 LABEL email="mark.piper@colorado.edu"
 
 ENV base_url=https://github.com/csdms
-ENV package=bmi-example-cxx
+ENV project=bmi-example-cxx
 ENV version="2.1.3"
-ENV prefix=/opt/${package}
+ENV prefix=/opt/${project}
 
-RUN git clone --branch v${version} ${base_url}/${package} ${prefix}
+RUN git clone --branch v${version} ${base_url}/${project} ${prefix}
 WORKDIR ${prefix}/_build
 RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
     make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-# Build the C++ BMI example from a Mambaforge (Linux/Ubuntu) image.
-FROM csdms/bmi:0.1.0
+# Build the C++ BMI example from a condaforge/miniforge3 (Linux/Ubuntu) base.
+FROM csdms/bmi:0.2.1
 
 LABEL author="Mark Piper"
 LABEL email="mark.piper@colorado.edu"
 
 ENV base_url=https://github.com/csdms
 ENV package=bmi-example-cxx
-ENV version="2.1.2"
+ENV version="2.1.3"
 ENV prefix=/opt/${package}
 
 RUN git clone --branch v${version} ${base_url}/${package} ${prefix}

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ docker build --tag bmi-example-cxx .
 ```
 The image is based on the [csdms/bmi](https://hub.docker.com/r/csdms/bmi) image.
 The OS is Linux/Ubuntu.
-`conda` and `mamba` are installed in `CONDA_DIR=/opt/conda`,
+`conda` is installed in `CONDA_DIR=/opt/conda`,
 and the *base* environment is activated.
-The C++ BMI specification and example, including the `run_bmiheatc` executable, are installed into it.
+The C++ BMI mapping and example, including the `run_bmiheatcxx` executable, are installed into it.
 
 ## Run a container
 


### PR DESCRIPTION
The csdms/bmi base image was previously built on mambaforge, but the latest version is built on miniforge. This PR updates the repository to reflect this change. 